### PR TITLE
7.5 Practice {subject} Unconstrained working

### DIFF
--- a/src/UI/panel_gui_tutor_practice_subject.py
+++ b/src/UI/panel_gui_tutor_practice_subject.py
@@ -249,7 +249,7 @@ agents_dict = {
 #  Define Agent Transitions: Unconstrained, Allowed, or Disallowed
 #
 ####################################################################################################
-TRANSITIONS = 'DISALLOWED'      # Set TRANSITIONS for type
+TRANSITIONS = 'UNCONSTRAINED'      # Set TRANSITIONS for type
 if TRANSITIONS == 'DISALLOWED':
 
     disallowed_agent_transitions = {


### PR DESCRIPTION
Unconstrained transition worked for “practice subject”

observations:
Disallowed: For this transition, I have tried different prompts regarding “practice subject” . Even though I specified that I want to practice subject exclusively, it doesn’t follow the flow and it did not give me any practice questions.

Allowed: For this transition, it absolutely not followed the flow and on top of that it was running in an infinite loop of conversations. I had to manually stop the application to stop the loop. 

Unconstrained: This option gave me closer results to the flow mentioned in the use case description. It mostly followed the flow with the exception that the agents talked to programmer agent and code runner agent afterwards.

