### PR TITLE
US19.1 and US19.2 Update reactive chat and panel gui tabs

### DIFF
--- a/src/UI/panel_gui_tabs19_priya.py
+++ b/src/UI/panel_gui_tabs19_priya.py
@@ -1,0 +1,63 @@
+
+
+import autogen
+import panel as pn
+import openai
+import os
+import asyncio
+from typing import List, Dict
+from src import globals
+from src.Agents.agents import *
+from src.Agents.chat_manager_fsms import FSM
+from src.Agents.group_chat_manager_agent import CustomGroupChatManager, CustomGroupChat
+from src.UI.reactive_chat_19 import ReactiveChat
+from src.UI.avatar import avatar
+import logging
+
+logging.basicConfig(level=logging.INFO,
+                    format='%(levelname)s - %(module)s - %(filename)s - %(funcName)s - line %(lineno)d - %(asctime)s - %(name)s - %(message)s')
+
+
+os.environ["AUTOGEN_USE_DOCKER"] = "False"
+
+
+##############################################
+# Main Adaptive Learning Application
+##############################################
+globals.input_future = None
+script_dir = os.path.dirname(os.path.abspath(__file__))
+progress_file_path = os.path.join(script_dir, '../../progress.json')
+
+fsm = FSM(agents_dict)
+
+groupchat = CustomGroupChat(agents=list(agents_dict.values()), 
+                              messages=[],
+                              max_round=globals.MAX_ROUNDS,
+                              send_introductions=True,
+                              speaker_selection_method=fsm.next_speaker_selector
+                              )
+
+manager = CustomGroupChatManager(groupchat=groupchat,
+                                filename=progress_file_path, 
+                                is_termination_msg=lambda x: x.get("content", "").rstrip().find("TERMINATE") >= 0 )    
+
+# Begin GUI components
+reactive_chat = ReactiveChat(groupchat_manager=manager)
+
+# Register groupchat_manager and reactive_chat GUI interface with ConversableAgents
+for agent in groupchat.agents:
+    agent.groupchat_manager = manager
+    agent.reactive_chat = reactive_chat
+    agent.register_reply([autogen.Agent, None], reply_func=agent.autogen_reply_func, config={"callback": None})
+
+reactive_chat.update_dashboard()    # Call after history loaded
+
+# Create app with speech recognition button
+def create_app():    
+    return pn.Column(
+        reactive_chat.draw_view()
+    )
+
+if __name__ == "__main__":    
+    app = create_app()
+    pn.serve(app, callback_exception='verbose')


### PR DESCRIPTION
[Increase width of question tab. Wrap text if needed. Isolate code changes to tabs19_priya.](https://github.com/lakshmipriya-dondapati/Priya-Adaptive-Learning/commit/407e93af1371343710980df3a9ec222c4aeae25d)

[Update logic to correctly choose the previous question](https://github.com/lakshmipriya-dondapati/Priya-Adaptive-Learning/commit/1036bd0df7d5e31e8dab0e6a0ae80da99df8af3c)

[For US19: As a developer, I want to enhance the progress tab in the GUI to show detailed results of user answers, distinguishing between correct and incorrect responses, to improve educational feedback and user engagement.](https://github.com/Rivier-Computer-Science/Adaptive-Learning/issues/227)

Implements:
US19.1: Design the updated layout for the progress tab to include detailed question and answer tracking (6 person-hours). #234

US19.2: Implement the new features in the progress tab using the existing Panel framework (10 person-hours). #235
